### PR TITLE
Huffman compression fixed thanks to gba-huff

### DIFF
--- a/libgrit/cprs.cpp
+++ b/libgrit/cprs.cpp
@@ -51,7 +51,7 @@ bool cprs_compress(RECORD *dst, const RECORD *src, ECprsTag tag)
 
 	//CPRS_HUF4_TAG
 	case CPRS_HUFF8_TAG:
-		bOK= huffgba_compress(dst, src, 8) != 0;	break;
+		bOK= huffgba_compress(dst, src) != 0;	break;
 
 	case CPRS_RLE_TAG:
 		bOK= rle8gba_compress(dst, src) != 0;		break;

--- a/libgrit/cprs.h
+++ b/libgrit/cprs.h
@@ -55,9 +55,7 @@ uint fake_decompress(RECORD *dst, const RECORD *src);
 uint lz77gba_compress(RECORD *dst, const RECORD *src);
 uint lz77gba_decompress(RECORD *dst, const RECORD *src);
 
-uint huffgba_compress(RECORD *dst, const RECORD *src, int srcB);
-//uint huf4gba_compress(RECORD *dst, const RECORD *src);
-uint huf8gba_compress(RECORD *dst, const RECORD *src);
+uint huffgba_compress(RECORD *dst, const RECORD *src);
 
 uint rle8gba_compress(RECORD *dst, const RECORD *src);
 uint rle8gba_decompress(RECORD *dst, const RECORD *src);

--- a/license-zlib.txt
+++ b/license-zlib.txt
@@ -1,0 +1,17 @@
+gba-huff is available under the [zlib license](https://www.zlib.net/zlib_license.html) :
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.


### PR DESCRIPTION
Huffman compression is replaced with [gba-huff](https://github.com/GValiente/gba-huff) compressor.

It fixes https://github.com/devkitPro/grit/issues/4, and I haven't had any issues with other data I have tested.

Since gba-huff is licensed under the zlib license, there should be no issues integrating it with grit.