### PR TITLE
Don't remove the renamed file

### DIFF
--- a/libgrit/grit_xp.cpp
+++ b/libgrit/grit_xp.cpp
@@ -414,7 +414,6 @@ bool grit_xp_c(GritRec *gr)
 		else
 		{
 			fclose(fout);
-			remove(fpath);
 		}
 	}
 	else
@@ -525,7 +524,6 @@ bool grit_xp_gas(GritRec *gr)
 		else
 		{
 			fclose(fout);
-			remove(fpath);
 		}
 	}
 	else
@@ -1153,7 +1151,6 @@ bool grit_xp_h(GritRec *gr)
 		else
 		{
 			fclose(fout);
-			remove(fpath);
 		}
 	}
 	else


### PR DESCRIPTION
When I fixed renaming across devices, I accidentally changed it to remove the destination path *after* the rename, instead of beforehand. This means that if the rename *works*, it'll...delete the file afterwards. This is obviously undesirable and since I'm the one who broke it, well,