### PR TITLE
Add flag to help text

### DIFF
--- a/srcgrit/grit_main.cpp
+++ b/srcgrit/grit_main.cpp
@@ -88,6 +88,7 @@ const char appHelpText[]=
 "-gx            Enable texture operations\n"
 "-gS            Shared graphics\n"
 "-gT{n}         Transparent color; rrggbb hex or 16bit BGR hex [FF00FF]\n"
+"                 -gT! forces alpha bit, only affects NDS"
 "-al{n}         Area left [0]\n"
 "-ar{n}         Area right (exclusive) [img width]\n"
 "-aw{n}         Area width [img width]. Overrides -ar\n"

--- a/srcgrit/grit_main.cpp
+++ b/srcgrit/grit_main.cpp
@@ -88,7 +88,7 @@ const char appHelpText[]=
 "-gx            Enable texture operations\n"
 "-gS            Shared graphics\n"
 "-gT{n}         Transparent color; rrggbb hex or 16bit BGR hex [FF00FF]\n"
-"                 -gT! forces alpha bit, only affects NDS"
+"                 -gT! forces alpha bit, only affects NDS\n"
 "-al{n}         Area left [0]\n"
 "-ar{n}         Area right (exclusive) [img width]\n"
 "-aw{n}         Area width [img width]. Overrides -ar\n"


### PR DESCRIPTION
Adds the `-gT!` flag to the help text, as it's currently not documented there