### PR TITLE
Fixed compiling with MSVC

### DIFF
--- a/libgrit/cprs_huff.cpp
+++ b/libgrit/cprs_huff.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <deque>
 #include <memory>
+#include <tuple>
 #include <vector>
 
 namespace

--- a/libgrit/grit_xp.cpp
+++ b/libgrit/grit_xp.cpp
@@ -35,7 +35,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <unistd.h>
+#ifndef _WIN32
+#   include <unistd.h>
+#endif
 
 #include <cldib_core.h>
 #include "grit.h"
@@ -180,6 +182,16 @@ uint grit_xp_total_size(GritRec *gr);
 static FILE* open_tmp_file(char* pathbuf, size_t pathbuf_sz,
 	const char* base_name)
 {
+#ifdef _WIN32
+    if (tmpnam_s(pathbuf, pathbuf_sz)) {
+        return NULL;
+    }
+
+    FILE* f = fopen(pathbuf, "w+");
+    if (f == NULL) {
+        return NULL;
+    }
+#else
 	snprintf(pathbuf, pathbuf_sz, "%s.tmp.XXXXXX", base_name);
 	int fd = mkstemp(pathbuf);
 	if (fd == -1) {
@@ -191,7 +203,7 @@ static FILE* open_tmp_file(char* pathbuf, size_t pathbuf_sz,
 		close(fd);
 		return NULL;
 	}
-
+#endif
 	return f;
 }
 


### PR DESCRIPTION
`libgrit/cprs_huff.cpp` was missing an include for `<tuple>` that is required for `std::tie`: https://en.cppreference.com/w/cpp/utility/tuple/tie

`libgrit/grit_xp.cpp` included `<unistd.h>` which is unavailable on MSVC. I have provided a Windows alternative implementation