### PR TITLE
safe typo -> load/save

### DIFF
--- a/cldib/cldib_files.h
+++ b/cldib/cldib_files.h
@@ -16,7 +16,7 @@ enum eCldibID
 	CLDIB_TGA
 };
 
-// If you just want to safe without fussing over CXxxFile definitions, 
+// If you just want to load/save without fussing over CXxxFile definitions,
 // use these, where Xxx is the file type, with start-caps 
 // (Bmp, Pcx, Png, etc)
 /*


### PR DESCRIPTION
"safe" is not a verb.

Also guys I don't know if you know but I tried opening an unrelated bug report on the devkitpro forums but it's still awaiting approval.  Are you short on staff?