### PR TITLE
Update cCTypes "int" to "long int"

### DIFF
--- a/libgrit/pathfun.cpp
+++ b/libgrit/pathfun.cpp
@@ -43,7 +43,7 @@
 
 
 const char cTypeSpec[]= "extern const unsigned";
-const char *cCTypes[]= { "", "char", "short", "", "int" };
+const char *cCTypes[]= { "", "char", "short", "", "long int" };
 const char *cGasTypes[]= { "", ".byte", ".hword", "", ".word" };
 
 


### PR DESCRIPTION
Since the libtonc release update
[v1.4.5](https://github.com/devkitPro/libtonc/releases/tag/v1.4.5), The libtonc types were updated to use "stdint.h/stdbool.h" [commit here](https://github.com/devkitPro/libtonc/commit/eb341b37fa257823304b9bfa985587c0f3234f4b). As of devkitARM version pacman version r66-1, devkitARM uses arm-none-eabi-gcc version 14.2.0 . Where it defines "uint32_t" as a "long unsigned", and similar for other 32-bit basic types. Grit should reflect this new change.