### PR TITLE
Fix misdetecting Mac OS X on Intel/ARM as big endian

### DIFF
--- a/cldib/cldib_core.h
+++ b/cldib/cldib_core.h
@@ -121,7 +121,7 @@ INLINE void write32be(BYTE *dst, DWORD src);
 */
 
 // PONDER: not sure I should do this, but we'll see
-#if (BYTE_ORDER == BIG_ENDIAN) || defined(__APPLE__)
+#if (BYTE_ORDER == BIG_ENDIAN)
 	#define CCID_RED   0
 	#define CCID_GREEN 1
 	#define CCID_BLUE  2


### PR DESCRIPTION
This fixes incorrect colours in generated files.