### PR TITLE
Fix unconditional insertion of zero-filled tile at start of tileset without map

### DIFF
--- a/cldib/cldib_tmap.cpp
+++ b/cldib/cldib_tmap.cpp
@@ -209,9 +209,8 @@ bool tmap_init_from_dib(Tilemap *tm, CLDIB *dib, int tileW, int tileH,
 	}
 	else
 	{
-		rdxN= 1;					
+		rdxN = 0;
 		rdx = dib_alloc(tileW, (mapN+rdxN)*tileH, dibB, NULL);
-		memset(dib_get_img(rdx), 0, dib_get_pitch(rdx)*tileH);
 		dib_pal_cpy(rdx, dib);
 	}
 


### PR DESCRIPTION
### Objective
Change tileset generation with maps to avoid unconditional zero-filled tiles at tileset start.

### Reason for change
When generating a tileset with a map, Grit always prepends a zero-filled tile (tile index 0) to the tileset, even when the source image does not contain any zero-filled tile.

This implicit tile does not correspond to any data in the input image.

### Why this is a problem

- It artificially increases the tileset size by one tile.
- It breaks the expectation that tilesets generated from images strictly reflect the source data.
- It can cause unexpected tile count overflows, most critically for affine_bg (hard 256-tile limit), but also for any workflow relying on precise tile counts.
- It introduces inconsistent behavior compared to tileset generation without a map, where no implicit zero-filled tile is added.

### Testing
Tested with various sizes, including the 256-tile affine_bg limit case.